### PR TITLE
Add `govuk-` prefix to `data-module` attributes

### DIFF
--- a/app/helpers/govuk_design_system/details_helper.rb
+++ b/app/helpers/govuk_design_system/details_helper.rb
@@ -14,7 +14,7 @@ module GovukDesignSystem
     #
     # rubocop:disable Naming/MethodName, Naming/UncommunicativeMethodParamName, Naming/VariableName
     def govukDetails(summaryText: nil, summaryHtml: nil, text: nil, html: nil, id: nil, open: nil, classes: '', attributes: {})
-      attributes.merge!("class" => "govuk-details #{classes}", id: id, "data-module" => "details")
+      attributes.merge!("class" => "govuk-details #{classes}", id: id, "data-module" => "govuk-details")
       attributes["open" => "open"] if open
 
       content_tag('details', attributes) do

--- a/app/views/components/_govuk_checkboxes.html.slim
+++ b/app/views/components/_govuk_checkboxes.html.slim
@@ -14,7 +14,7 @@ ruby:
     - described_by = described_by.present? ? described_by + ' ' + error_id : error_id
     = render "components/govuk_error_message", id: error_id, **errorMessage
   .govuk-checkboxes [*(local_assigns[:attributes] || {})
-                     class=local_assigns[:classes] data-module=("checkboxes" if is_conditional)]
+                     class=local_assigns[:classes] data-module=("govuk-checkboxes" if is_conditional)]
     - items.each_with_index do |item, i|
       - id = item[:id] || "#{id_prefix}-#{i}"
       - conditional_id = 'conditional-' + id

--- a/app/views/components/_govuk_error_summary.html.slim
+++ b/app/views/components/_govuk_error_summary.html.slim
@@ -3,7 +3,7 @@
 /       943ff14752f0a8a765ee3f90bc3e1ecd9205e36c/src/components/error-summary/template.njk
 
 - attributes = { \
-        "data-module": "error-summary",
+        "data-module": "govuk-error-summary",
         "class": local_assigns[:classes],
         "aria-labelby": "error-summary-title",
         role: "alert",

--- a/app/views/components/_govuk_header.html.slim
+++ b/app/views/components/_govuk_header.html.slim
@@ -3,7 +3,7 @@
 /     blob/57442fc51f088b0a5a3c7aaef085abb7f039fe8f/src/components/header/template.njk
 
 - attributes = (local_assigns[:attributes] || {})
-header.govuk-header *attributes class=local_assigns[:classes] role="banner" data-module="header"
+header.govuk-header *attributes class=local_assigns[:classes] role="banner" data-module="govuk-header"
   .govuk-header__container class=(local_assigns[:containerClasses] || "govuk-width-container")
     .govuk-header__logo
       a.govuk-header__link.govuk-header__link--homepage href=(local_assigns[:containerClasses] || "/")

--- a/app/views/components/_govuk_radios.html.slim
+++ b/app/views/components/_govuk_radios.html.slim
@@ -16,7 +16,7 @@ ruby:
     = render "components/govuk_error_message", id: error_id, **errorMessage
   - radios_classes = [local_assigns[:classes]]
   - radios_classes.push "govuk-radios--conditional" if is_conditional
-  .govuk-radios *(local_assigns[:attributes] || {}) class=radios_classes data-module=("radios" if is_conditional)
+  .govuk-radios *(local_assigns[:attributes] || {}) class=radios_classes data-module=("govuk-radios" if is_conditional)
     - items.each_with_index do |item, i|
       - id = item[:id] || "#{id_prefix}-#{i}"
       - conditional_id = 'conditional-' + id

--- a/app/views/components/_govuk_tabs.html.slim
+++ b/app/views/components/_govuk_tabs.html.slim
@@ -2,7 +2,7 @@ ruby:
   id_prefix = local_assigns[:idPrefix]
   attributes = local_assigns[:attributes] || {}
 
-.govuk-tabs *attributes class=local_assigns[:classes] id=local_assigns[:id] data-module="tabs"
+.govuk-tabs *attributes class=local_assigns[:classes] id=local_assigns[:id] data-module="govuk-tabs"
   h2.govuk-tabs__title
     = local_assigns[:title] || "Contents"
   ul.govuk-tabs__list


### PR DESCRIPTION
This is for compatibility with [version 3.0.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.0.0) of the govuk-frontend, which addes a prefix to `data-module` attributes to avoid namespacing conflicts. See [issue 1443](https://github.com/alphagov/govuk-frontend/pull/1443)