### PR TITLE
Add back link helper

### DIFF
--- a/app/helpers/govuk_design_system/back_link_helper.rb
+++ b/app/helpers/govuk_design_system/back_link_helper.rb
@@ -1,0 +1,14 @@
+module GovukDesignSystem
+  module GovukBackLinkHelper
+
+    # Use the [back link component](https://design-system.service.gov.uk/components/back-link/)
+    # to help users go back to the previous page in a multi-page transaction.
+    #
+    # Code based upon [nunjucks template](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/back-link/template.njk)
+    def govukBackLink(text: nil, html: nil, href:, classes: "", attributes: {})
+      attributes[:class] = "govuk-back-link #{classes}"
+
+      link_to (html || text), href, attributes
+    end
+  end
+end


### PR DESCRIPTION
Adds a `govukBackLink` helper, using the same parameters as the Nunjucks macro from govuk-frontend.