### PR TITLE
Add summary list helper

### DIFF
--- a/app/helpers/govuk_design_system/details_helper.rb
+++ b/app/helpers/govuk_design_system/details_helper.rb
@@ -1,6 +1,5 @@
 module GovukDesignSystem
   module DetailsHelper
-
     # Generates the HTML for the
     # [Details component](https://design-system.service.gov.uk/components/details/)
     # from the GOV.UK Design System.

--- a/app/helpers/govuk_design_system/summary_list_helper.rb
+++ b/app/helpers/govuk_design_system/summary_list_helper.rb
@@ -1,0 +1,47 @@
+module GovukDesignSystem
+  module GovukSummaryListHelper
+    # Use the [summary list](https://design-system.service.gov.uk/components/summary-list/)
+    # to summarise information, for example, a user’s responses at the end of a form.
+    #
+    # Implementation based on [nunjucks template](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/summary-list/template.njk)
+    def govukSummaryList(rows: [], classes: "", attributes: {})
+      attributes[:class] = "govuk-summary-list #{classes}"
+
+      # Determine if we need 2 or 3 columns
+      anyRowHasActions = rows.detect { |row| row.fetch(:actions, {})[:items] }
+
+      content_tag("dl", attributes) do
+        rows.each do |row|
+          row = content_tag("div", class: "govuk-summary-list__row") do
+            concat content_tag("dt", (row[:key][:html] || row[:key][:text]), class: "govuk-summary-list__key")
+            concat content_tag("dd", (row[:value][:html] || row[:value][:text]), class: "govuk-summary-list__value")
+
+            if !row.fetch(:actions, {}).fetch(:items, []).empty?
+
+              actions = content_tag("dd", class: "govuk-summary-list__actions") do
+                row[:actions][:items].each do |item|
+                  link = link_to(item[:href]) do
+                    concat (item[:html] || item[:text])
+                    if item[:visuallyHiddenText]
+                      concat " "
+                      concat content_tag("span", item[:visuallyHiddenText], class: "govuk-visually-hidden")
+                    end
+                  end
+                  concat link
+                end
+              end
+
+              concat actions
+
+            elsif anyRowHasActions
+              # Add dummy column to extend border #
+              concat content_tag("span", "", class: "govuk-summary-list__actions")
+            end
+          end
+
+          concat row
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/govuk_design_system/warning_text_helper.rb
+++ b/app/helpers/govuk_design_system/warning_text_helper.rb
@@ -1,23 +1,20 @@
 module GovukDesignSystem
   module WarningTextHelper
-
     # Use the [warning text component](https://design-system.service.gov.uk/components/warning-text/)
     # when you need to warn users about something important, such as legal consequences of an action,
     # or lack of action, that they might take.
     #
     # Implementation based on https://github.com/alphagov/govuk-frontend/tree/master/src/govuk/components/warning-text
     def govukWarningText(text: nil, html: nil, iconFallbackText:, classes: "", attributes: {})
-
       attributes[:class] = "govuk-warning-text #{classes}"
 
       content_tag('div', attributes) do
         content_tag('span', '!', class: 'govuk-warning-text__icon', "aria-hidden" => 'true') +
-        content_tag('strong', class: 'govuk-warning-text__text') do
-          content_tag('span', iconFallbackText, class: 'govuk-warning-text__assistive') +
-          (html || text)
-        end
+          content_tag('strong', class: 'govuk-warning-text__text') do
+            content_tag('span', iconFallbackText, class: 'govuk-warning-text__assistive') +
+              (html || text)
+          end
       end
     end
-
   end
 end


### PR DESCRIPTION
Adds a `govukSummaryList` helper, based on the Nunjucks macro from `govuk-frontend`.