### PR TITLE
Add "phase banner" and "tag" helpers

### DIFF
--- a/app/helpers/govuk_design_system/phase_banner_helper.rb
+++ b/app/helpers/govuk_design_system/phase_banner_helper.rb
@@ -1,0 +1,21 @@
+module GovukDesignSystem
+  module PhaseBannerHelper
+    # Generates the HTML for the
+    # [Phase banner component](https://design-system.service.gov.uk/components/phase-banner/)
+    # from the GOV.UK Design System.
+    #
+    # Use the phase banner component to show users your service is still being worked on.
+    #
+    # Implementation based on https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/details/
+    def govukPhaseBanner(text: nil, html: nil, tag: nil, classes: '', attributes: {})
+      attributes["class"] = "govuk-phase-banner #{classes}"
+
+      content_tag("div", attributes) do
+        content_tag("p", {class: "govuk-phase-banner__content"}) do
+          concat govukTag(text: tag[:text], html: tag[:html], classes: "govuk-phase-banner__content__tag #{tag[:classes]}")
+          concat content_tag("span", (html || text), {class: "govuk-phase-banner__text"})
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/govuk_design_system/tag_helper.rb
+++ b/app/helpers/govuk_design_system/tag_helper.rb
@@ -1,0 +1,16 @@
+module GovukDesignSystem
+  module TagHelper
+    # Generates the HTML for the
+    # [Tag component](https://design-system.service.gov.uk/components/tag/)
+    # from the GOV.UK Design System.
+    #
+    # Use the tag component to indicate the status of something, such as an item
+    # on a task list or a phase banner.
+    #
+    # Implementation based on https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/tag/template.njk
+    def govukTag(text: nil, html: nil, classes: "", attributes: {})
+      attributes["class"] = "govuk-tag #{classes}"
+      content_tag("strong", (html || text), attributes)
+    end
+  end
+end


### PR DESCRIPTION
This adds helpers which generate the HTML for the [phase banner](https://design-system.service.gov.uk/components/phase-banner/) and [tag](https://design-system.service.gov.uk/components/tag/) components from the [GOV.UK Design System](https://design-system.service.gov.uk).