### PR TITLE
Fix broken aria-describedby attribute on checkbox component

### DIFF
--- a/app/views/components/_govuk_checkboxes.html.slim
+++ b/app/views/components/_govuk_checkboxes.html.slim
@@ -1,4 +1,4 @@
-/https://github.com/alphagov/govuk-frontend/blob/master/src/components/checkboxes/template.njk
+/https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/checkboxes/template.njk
 ruby:
   id_prefix = (local_assigns[:idPrefix].presence || name).to_s
   described_by = ""
@@ -41,8 +41,8 @@ ruby:
             checked=item[:checked]
             disabled=item[:disabled]
             data-aria-controls=(conditional_id if item[:conditional])
-            aria-describedby="#{described_by if !has_fieldset && described_by.present?}\
-            #{item_hint_id if has_hint}".presence
+            aria-describedby=("#{described_by if !has_fieldset && described_by.present?}\
+            #{item_hint_id if has_hint}".presence)
             *(item[:attributes] || {})]
           - if item[:type] != "hidden"
             = render "components/govuk_label",


### PR DESCRIPTION
This fixes the `aria-describedby` output on the checkbox com ponent being broken and outputting an additional `.presence` attribute due to a syntax error in the Slim template.

Before:

```html
<input .presence="" aria-describedby=" " class="govuk-checkboxes__input" id="assigned_to_team_0" name="assigned_to_team_0" type="checkbox" value="a26a4dac-4f47-464d-b84f-048c4b8e9602">
```

After:

```html
<input class="govuk-checkboxes__input" id="assigned_to_team_0" name="assigned_to_team_0" type="checkbox" value="a26a4dac-4f47-464d-b84f-048c4b8e9602">
```