### PR TITLE
Bugfix: highlight errors if overall date field in error

### DIFF
--- a/app/views/form_components/_govuk_date_input.html.slim
+++ b/app/views/form_components/_govuk_date_input.html.slim
@@ -5,25 +5,26 @@ ruby:
   # Infer name and id_prefix from attribute key
   local_assigns[:id] ||= get_attribute_id_prefix(form, key)
   errors = form.object.errors
+  date_errors = errors.full_messages_for(key.to_sym)
   day_errors = errors.full_messages_for("#{key}_day".to_sym)
   month_errors = errors.full_messages_for("#{key}_month".to_sym)
   year_errors = errors.full_messages_for("#{key}_year".to_sym)
   local_assigns[:items] = [
           {
                   label: "day",
-                  classes: "govuk-input--width-2 #{'govuk-input--error' if day_errors.any?}",
+                  classes: "govuk-input--width-2 #{'govuk-input--error' if day_errors.any? || date_errors.any?}",
                   value: form.object.send(:get_day, key),
                   name: "#{get_attribute_name(form, key)}[day]"
           },
           {
                   label: "month",
-                  classes: "govuk-input--width-2 #{'govuk-input--error' if month_errors.any?}",
+                  classes: "govuk-input--width-2 #{'govuk-input--error' if month_errors.any? || date_errors.any?}",
                   value: form.object.send(:get_month, key),
                   name: "#{get_attribute_name(form, key)}[month]"
           },
           {
                   label: "year",
-                  classes: "govuk-input--width-4 #{'govuk-input--error' if year_errors.any?}",
+                  classes: "govuk-input--width-4 #{'govuk-input--error' if year_errors.any? || date_errors.any?}",
                   value: form.object.send(:get_year, key),
                   name: "#{get_attribute_name(form, key)}[year]"
           }


### PR DESCRIPTION
This fixes a bug whereby if the overall date field has an error (eg all 3 inputs are blank), the fields weren’t receiving a red border.

See https://trello.com/c/b3N6BwTm/33-date-component-doesnt-have-the-correct-error-styling