### PR TITLE
Bugfix: typo in ARIA attribute

### DIFF
--- a/app/views/components/_govuk_error_summary.html.slim
+++ b/app/views/components/_govuk_error_summary.html.slim
@@ -5,7 +5,7 @@
 - attributes = { \
         "data-module": "govuk-error-summary",
         "class": local_assigns[:classes],
-        "aria-labelby": "error-summary-title",
+        "aria-labelledby": "error-summary-title",
         role: "alert",
         tabindex: "-1" }.merge(local_assigns[:attributes] || {})
 .govuk-error-summary *attributes


### PR DESCRIPTION
Attribute should be [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute) not `aria-labelby`.