### PR TITLE
Remove unneeded id and class

### DIFF
--- a/app/views/components/_govuk_select.html.slim
+++ b/app/views/components/_govuk_select.html.slim
@@ -40,7 +40,7 @@ ruby:
       = select
     - if local_assigns[:show_all_values]
       button id="clear-#{id}" class="autocomplete__clear-button" type="button" style="display: none;"
-        span#delete-hint.govuk-hint.govuk-visually-hidden
+        span.govuk-visually-hidden
           | Clear autocomplete
         svg viewbox="0 0 40 40" class="autocomplete__clear-viewbox"
           path class="autocomplete__clear-icon" d="M 10,10 L 30,30 M 30,10 L 10,30"


### PR DESCRIPTION
This `id` value is unneeded and can cause duplicate element IDs to be present on a page if there are more than one autocompletes.

The `govuk-hint` class is also not needed as this is visually-hidden text.