### PR TITLE
Bugfix: "open" attribute for details helper

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,4 +14,4 @@ DEPENDENCIES
   govuk-design-system-rails!
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/app/helpers/govuk_design_system/details_helper.rb
+++ b/app/helpers/govuk_design_system/details_helper.rb
@@ -14,7 +14,7 @@ module GovukDesignSystem
     # rubocop:disable Naming/MethodName, Naming/UncommunicativeMethodParamName, Naming/VariableName
     def govukDetails(summaryText: nil, summaryHtml: nil, text: nil, html: nil, id: nil, open: nil, classes: '', attributes: {})
       attributes.merge!("class" => "govuk-details #{classes}", id: id, "data-module" => "govuk-details")
-      attributes["open" => "open"] if open
+      attributes["open"] = "open" if open
 
       content_tag('details', attributes) do
         summary = content_tag('summary', class: 'govuk-details__summary') do


### PR DESCRIPTION
The code was checking for the attribute with key:
"open => open" instead of assigning a key/value into the hash.
As a result, when providing "open" flag to the method it wasn't applied.