### PR TITLE
Exclude radio button dividers from getting checked

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (0.3.0)
+    govuk-design-system-rails (0.6.7)
 
 GEM
   remote: https://rubygems.org/

--- a/app/views/form_components/_govuk_radios.html.slim
+++ b/app/views/form_components/_govuk_radios.html.slim
@@ -15,7 +15,7 @@ ruby:
   if form.object.respond_to?(key)
     # Make item checked based on attribute value
     item_matching_state = items.find do |item|
-      !item[:divider] && item[:value].to_s == form.object.send(key).to_s
+      !item[:divider] && item[:value].to_s == form.object.public_send(key).to_s
     end
     item_matching_state[:checked] = true if item_matching_state
   end

--- a/app/views/form_components/_govuk_radios.html.slim
+++ b/app/views/form_components/_govuk_radios.html.slim
@@ -14,7 +14,9 @@ ruby:
   end
   if form.object.respond_to?(key)
     # Make item checked based on attribute value
-    item_matching_state = items.find { |item| item[:value].to_s == form.object.send(key).to_s }
+    item_matching_state = items.find do |item|
+      !item[:divider] && item[:value].to_s == form.object.send(key).to_s
+    end
     item_matching_state[:checked] = true if item_matching_state
   end
   unless form.object.nil?

--- a/govuk_design_system-rails.gemspec
+++ b/govuk_design_system-rails.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name        = "govuk-design-system-rails"
-  s.version     = "0.6.6"
+  s.version     = "0.6.7"
   s.authors     = %w(UKGovernmentBEIS)
   s.summary     = "An implementation of the govuk-frontend macros in Ruby on Rails"
 end


### PR DESCRIPTION
Divider elements in the radio buttons have no "value" key.
If the form element value to match with the radio buttons is `nil` or `""`, then it will be matched against the divider elem (as its value is `nil`).
So the "selected item" in the resulting radio button will be the divider, and the divider (`or` or similar) is not meant to be selected.
This commit resolves it by excluding dividers from the radio button item selection.