### PR TITLE
Use input type of text with inputmode of "numeric"

### DIFF
--- a/app/views/components/_govuk_date_input.html.slim
+++ b/app/views/components/_govuk_date_input.html.slim
@@ -32,7 +32,8 @@ ruby:
                 classes: "govuk-date-input__input #{item[:classes]}",
                 name: local_assigns[:namePrefix] ? "#{local_assigns[:namePrefix]}-#{item[:name]}" : item[:name],
                 value: item[:value],
-                type: "number",
+                type: "text",
+                inputmode: "numeric",
                 autocomplete: item[:autocomplete],
                 pattern: item[:pattern] || "[0-9]*",
                 attributes: item[:attributes]


### PR DESCRIPTION
The GOV.UK Design System team [found that type=number has some accessibility and usability issues](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/) which were resolved by using `type=text` and `inputmode=numeric` instead.

This update our component implementation to [match the Nunjucks implementation](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/date-input/template.njk).