### PR TITLE
Accept inputmode attribute

### DIFF
--- a/app/views/components/_govuk_input.html.slim
+++ b/app/views/components/_govuk_input.html.slim
@@ -28,5 +28,6 @@ ruby:
                 type=(local_assigns[:type] || 'text')
                 value=local_assigns[:value]
                 pattern=local_assigns[:pattern]
+                inputmode=local_assigns[:inputmode]
                 aria-describedby=described_by.presence
                 autocomplete=local_assigns[:autocomplete]]


### PR DESCRIPTION
This updates the input component to accept the `inputmode` attribute, which is used by the date component.