### PR TITLE
Add checkboxes helper

### DIFF
--- a/app/helpers/govuk_design_system/checkboxes_helper.rb
+++ b/app/helpers/govuk_design_system/checkboxes_helper.rb
@@ -1,0 +1,90 @@
+module GovukDesignSystem
+  module CheckboxesHelper
+
+    def govukCheckboxes(items: [], classes: "", formGroup: {}, attributes: {}, describedBy: "", fieldset: {}, hint: nil, errorMessage: nil)
+      attributes[:class] = "govuk-checkboxes #{classes}"
+
+      # a record of other elements that we need to associate with the input using
+      # aria-describedby – for example hints or error messages -#}
+      describedBy = fieldset[:describedBy] || describedBy
+
+      idPrefix = ""
+
+      # Do any of the items have conditional HTML associated?
+      isConditional = items.detect { |item| item.dig(:conditional, :html) }
+
+      # Capture the HTML so we can optionally nest it in a fieldset
+      inner_html = capture do
+        html = ""
+
+        if hint
+
+          hintId = idPrefix + "-hint"
+          describedBy += " #{hintId}"
+
+          html += govukHint(
+            id: hintId,
+            classes: hint[:classes],
+            attributes: hint[:attributes],
+            html: hint[:html],
+            text: hint[:text]
+          )
+        end
+
+        if errorMessage
+          errorId = idPrefix + "-error"
+          describedBy += " #{errorId}"
+
+          html += govukErrorMessage(
+            id: errorId,
+            classes: errorMessage[:classes],
+            attributes: errorMessage[:attributes],
+            html: errorMessage[:html],
+            text: errorMessage[:text],
+            visuallyHiddenText: errorMessage[:visuallyHiddenText]
+          )
+        end
+
+        html += tag.div attributes do
+          items.each do |item|
+            item_html = capture do
+              tag.div class: "govuk-checkboxes__item" do
+                concat tag.input class: "govuk-checkboxes__input",
+                                 id: item[:id],
+                                 name: item[:name],
+                                 type: "checkbox",
+                                 value: item[:value],
+                                 checked: item[:checked]
+
+                concat govukLabel(
+                  classes: "govuk-checkboxes__label",
+                  text: item[:text],
+                  for: item[:id]
+                )
+              end
+            end
+
+            concat item_html
+          end
+        end
+
+        html.html_safe
+      end
+
+      form_group_classes = "govuk-form-group"
+      form_group_classes += " govuk-form-group--error" if errorMessage
+      form_group_classes += " #{formGroup[:classes]}" if formGroup[:classes]
+
+      tag.div class: form_group_classes do
+        govukFieldset(
+          describedBy: describedBy,
+          classes: fieldset[:classes],
+          attributes: fieldset[:attributes],
+          legend: fieldset[:legend]
+        ) do
+          inner_html
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/govuk_design_system/fieldset_helper.rb
+++ b/app/helpers/govuk_design_system/fieldset_helper.rb
@@ -1,0 +1,24 @@
+module GovukDesignSystem
+
+  # Based on https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/fieldset/template.njk
+  module FieldsetHelper
+    def govukFieldset(classes: "", describedBy: "", legend: {}, attributes: {}, &block)
+      tag.fieldset class: "govuk-fieldset" do
+        legend = capture do
+          tag.legend class: "govuk-fieldset__legend #{legend[:classes]}" do
+            if legend[:isPageHeading]
+              tag.h1 class: "govuk-fieldset__heading" do
+                legend[:html].presence || legend[:text]
+              end
+            else
+              legend[:html].presence || legend[:text]
+            end
+          end
+        end
+        content = capture(&block)
+
+        legend + content
+      end
+    end
+  end
+end

--- a/govuk_design_system-rails.gemspec
+++ b/govuk_design_system-rails.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name        = "govuk-design-system-rails"
-  s.version     = "0.6.8"
+  s.version     = "0.7.0"
   s.authors     = %w(UKGovernmentBEIS)
   s.summary     = "An implementation of the govuk-frontend macros in Ruby on Rails"
 end


### PR DESCRIPTION
Add `govukCheckboxes` helper, following the conventions and output of the [govukCheckboxes nunjucks macro](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/checkboxes/template.njk). This also requires a `govukFieldset` helper, which has been added too.