### PR TITLE
Resolve deprecated usage warning in Ruby 2.7

### DIFF
--- a/app/helpers/govuk_design_system/checkboxes_helper.rb
+++ b/app/helpers/govuk_design_system/checkboxes_helper.rb
@@ -10,9 +10,6 @@ module GovukDesignSystem
 
       idPrefix = ""
 
-      # Do any of the items have conditional HTML associated?
-      isConditional = items.detect { |item| item.dig(:conditional, :html) }
-
       # Capture the HTML so we can optionally nest it in a fieldset
       inner_html = capture do
         html = ""
@@ -45,7 +42,7 @@ module GovukDesignSystem
           )
         end
 
-        html += tag.div attributes do
+        html += tag.div(**attributes) do
           items.each do |item|
             item_html = capture do
               tag.div class: "govuk-checkboxes__item" do

--- a/app/helpers/govuk_design_system/error_summary_helper.rb
+++ b/app/helpers/govuk_design_system/error_summary_helper.rb
@@ -12,7 +12,7 @@ module GovukDesignSystem
       attributes[:tabindex] = "-1"
       attributes[:"data-module"] = "govuk-error-summary"
 
-      tag.div attributes do
+      tag.div(**attributes) do
         tag.h2((titleHtml || titleText), class: "govuk-error-summary__title", id: "error-summary-title") + \
         tag.div(class: "govuk-error-summary__body") do
           description = if descriptionHtml || descriptionText

--- a/govuk_design_system-rails.gemspec
+++ b/govuk_design_system-rails.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name        = "govuk-design-system-rails"
-  s.version     = "0.7.0"
+  s.version     = "0.7.1"
   s.authors     = %w(UKGovernmentBEIS)
   s.summary     = "An implementation of the govuk-frontend macros in Ruby on Rails"
 end


### PR DESCRIPTION
Resolves the following warning message when using with Ruby 2.7:

```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```