### PR TITLE
Add "nonce" to inline Javascript

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (0.6.7)
+    govuk-design-system-rails (0.7.1)
 
 GEM
   remote: https://rubygems.org/
@@ -14,4 +14,4 @@ DEPENDENCIES
   govuk-design-system-rails!
 
 BUNDLED WITH
-   2.1.4
+   2.2.13

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (0.7.1)
+    govuk-design-system-rails (0.7.2)
 
 GEM
   remote: https://rubygems.org/

--- a/app/views/components/_govuk_select.html.slim
+++ b/app/views/components/_govuk_select.html.slim
@@ -44,7 +44,7 @@ ruby:
           | Clear autocomplete
         svg viewbox="0 0 40 40" class="autocomplete__clear-viewbox"
           path class="autocomplete__clear-icon" d="M 10,10 L 30,30 M 30,10 L 10,30"
-    javascript:
-      window.callAutocompleteWhenReady("#{id}", {showAllValues: "#{local_assigns[:show_all_values]}"});
+    == javascript_tag nonce: true do
+       | window.callAutocompleteWhenReady("#{id}", {showAllValues: "#{local_assigns[:show_all_values]}"});
   - else
     = select

--- a/app/views/layouts/govuk_design_system/_head.html.slim
+++ b/app/views/layouts/govuk_design_system/_head.html.slim
@@ -30,8 +30,9 @@ html.govuk-template.app-html-class[lang="en"]
 
     = yield
 
-    javascript:
-      if (typeof window.GOVUKFrontend === 'undefined') {
+    == javascript_tag nonce: true do
+       |
+         if (typeof window.GOVUKFrontend === 'undefined') {
           document.body.className = document.body.className.replace('js-enabled', '')
-      }
-      window.GOVUKFrontend.initAll()
+         }
+         window.GOVUKFrontend.initAll()

--- a/govuk_design_system-rails.gemspec
+++ b/govuk_design_system-rails.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name        = "govuk-design-system-rails"
-  s.version     = "0.7.1"
+  s.version     = "0.7.2"
   s.authors     = %w(UKGovernmentBEIS)
   s.summary     = "An implementation of the govuk-frontend macros in Ruby on Rails"
 end


### PR DESCRIPTION
Rails services using this gem have Content Security Policy (CSP) restrictions that raise errors/alerts when untrusted inline Javascript is loaded.

To avoid that, we adopted the "nonce" approach. When using `javascript_tag` with the `nonce` flag to declare inline JS, Rails will generate a "nonce" random ID per request and set this nonce in each of the inline JS blocks where the "nonce" flag has been set. 
This way, Rails will identify if the inline JS is authorised/unidentified, and only the unidentified ones will raise CSP errors.

## Proof of this working on the client service using this gem changes

### The ruby interpolation inside the JS works after the changes. Values are loaded:
![Screenshot from 2021-04-07 10-36-35](https://user-images.githubusercontent.com/1227578/113847370-51988680-978f-11eb-85f4-44e222f1c135.png)

### Different inline scripts get the same nonce value

![Screenshot from 2021-04-07 10-34-33](https://user-images.githubusercontent.com/1227578/113847842-c7045700-978f-11eb-9e3e-4e0b00a553ad.png)

### STAGING: Using inline JS without the nonce. It still has the CSP error:
![Screenshot from 2021-04-07 10-22-05](https://user-images.githubusercontent.com/1227578/113848049-fca94000-978f-11eb-9e1b-ffa39a224b0d.png)

### Review APP: Using inline JS with the nonce. No CSP errors:
![Screenshot from 2021-04-07 10-22-28](https://user-images.githubusercontent.com/1227578/113848146-177bb480-9790-11eb-82bb-4f979002b278.png)

