### PR TITLE
Declare runtime dependency on Slim gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,17 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (0.7.5)
+    govuk-design-system-rails (0.7.6)
+      slim
 
 GEM
   remote: https://rubygems.org/
   specs:
+    slim (4.1.0)
+      temple (>= 0.7.6, < 0.9)
+      tilt (>= 2.0.6, < 2.1)
+    temple (0.8.2)
+    tilt (2.0.10)
 
 PLATFORMS
   ruby

--- a/govuk_design_system-rails.gemspec
+++ b/govuk_design_system-rails.gemspec
@@ -2,7 +2,9 @@ $:.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name        = "govuk-design-system-rails"
-  s.version     = "0.7.5"
+  s.version     = "0.7.6"
   s.authors     = %w(UKGovernmentBEIS)
   s.summary     = "An implementation of the govuk-frontend macros in Ruby on Rails"
+
+  s.add_runtime_dependency "slim"
 end


### PR DESCRIPTION
Adds the Slim gem to the runtime dependencies list so that applications do not need to explicitly include it in their bundle.

Note: the Slim templates will be migrated to ERB soon.