### PR TITLE
Allow to pass "described by" for all components

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (0.7.6)
+    govuk-design-system-rails (0.7.7)
       slim-rails
 
 GEM

--- a/app/views/components/_govuk_checkboxes.html.slim
+++ b/app/views/components/_govuk_checkboxes.html.slim
@@ -1,7 +1,7 @@
 /https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/checkboxes/template.njk
 ruby:
   id_prefix = (local_assigns[:idPrefix].presence || name).to_s
-  described_by = local_assigns[:described_by].presence || ""
+  described_by = local_assigns[:described_by] || ""
   is_conditional = items.any? { |item| item[:conditional] }
   has_fieldset = local_assigns[:fieldset].present?
 - checkboxes_html = capture do

--- a/app/views/components/_govuk_checkboxes.html.slim
+++ b/app/views/components/_govuk_checkboxes.html.slim
@@ -1,7 +1,7 @@
 /https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/checkboxes/template.njk
 ruby:
   id_prefix = (local_assigns[:idPrefix].presence || name).to_s
-  described_by = ""
+  described_by = local_assigns[:described_by].presence || ""
   is_conditional = items.any? { |item| item[:conditional] }
   has_fieldset = local_assigns[:fieldset].present?
 - checkboxes_html = capture do

--- a/app/views/components/_govuk_date_input.html.slim
+++ b/app/views/components/_govuk_date_input.html.slim
@@ -2,7 +2,7 @@
 / https://github.com/alphagov/govuk-frontend/
 / blob/b863be549f502a6829a5d261976c3bcb8ebdf4d2/src/components/date-input/template.njk
 ruby:
-  described_by = ""
+  described_by = local_assigns[:described_by].presence || ""
   date_input_items = local_assigns[:items] ||
           [
                   { name: "day", classes: "govuk-input--width-2" },

--- a/app/views/components/_govuk_date_input.html.slim
+++ b/app/views/components/_govuk_date_input.html.slim
@@ -2,7 +2,7 @@
 / https://github.com/alphagov/govuk-frontend/
 / blob/b863be549f502a6829a5d261976c3bcb8ebdf4d2/src/components/date-input/template.njk
 ruby:
-  described_by = local_assigns[:described_by].presence || ""
+  described_by = local_assigns[:described_by] || ""
   date_input_items = local_assigns[:items] ||
           [
                   { name: "day", classes: "govuk-input--width-2" },

--- a/app/views/components/_govuk_input.html.slim
+++ b/app/views/components/_govuk_input.html.slim
@@ -2,7 +2,7 @@
 / https://github.com/alphagov/govuk-frontend/
 / blob/b863be549f502a6829a5d261976c3bcb8ebdf4d2/src/components/input/template.njk
 ruby:
-  described_by = local_assigns[:described_by].presence || ""
+  described_by = local_assigns[:described_by] || ""
   form_group_classes = [local_assigns.dig(:formGroup, :classes)]
   form_group_classes.push "govuk-form-group--error" if local_assigns[:errorMessage]
   input_classes = ["govuk-input", local_assigns[:classes]]

--- a/app/views/components/_govuk_radios.html.slim
+++ b/app/views/components/_govuk_radios.html.slim
@@ -3,7 +3,7 @@
 /       blob/943ff14752f0a8a765ee3f90bc3e1ecd9205e36c/src/components/radios/template.njk
 ruby:
   id_prefix = (local_assigns[:idPrefix].presence || name).to_s
-  described_by = local_assigns[:described_by].presence || ""
+  described_by = local_assigns[:described_by] || ""
   is_conditional = items.any? { |item| item[:conditional] }
 - radios_html = capture do
   - if local_assigns[:hint].present?

--- a/app/views/components/_govuk_radios.html.slim
+++ b/app/views/components/_govuk_radios.html.slim
@@ -3,7 +3,7 @@
 /       blob/943ff14752f0a8a765ee3f90bc3e1ecd9205e36c/src/components/radios/template.njk
 ruby:
   id_prefix = (local_assigns[:idPrefix].presence || name).to_s
-  described_by = ""
+  described_by = local_assigns[:described_by].presence || ""
   is_conditional = items.any? { |item| item[:conditional] }
 - radios_html = capture do
   - if local_assigns[:hint].present?

--- a/app/views/components/_govuk_select.html.slim
+++ b/app/views/components/_govuk_select.html.slim
@@ -2,7 +2,7 @@
 / https://github.com/alphagov/govuk-frontend/
 / blob/b863be549f502a6829a5d261976c3bcb8ebdf4d2/src/components/select/template.njk
 ruby:
-  described_by = ""
+  described_by = local_assigns[:described_by].presence || ""
   form_group_classes = [local_assigns.dig(:formGroup, :classes)]
   form_group_classes.push "govuk-form-group--error" if local_assigns[:errorMessage]
   select_classes = ["govuk-select", local_assigns[:classes]]

--- a/app/views/components/_govuk_select.html.slim
+++ b/app/views/components/_govuk_select.html.slim
@@ -2,7 +2,7 @@
 / https://github.com/alphagov/govuk-frontend/
 / blob/b863be549f502a6829a5d261976c3bcb8ebdf4d2/src/components/select/template.njk
 ruby:
-  described_by = local_assigns[:described_by].presence || ""
+  described_by = local_assigns[:described_by] || ""
   form_group_classes = [local_assigns.dig(:formGroup, :classes)]
   form_group_classes.push "govuk-form-group--error" if local_assigns[:errorMessage]
   select_classes = ["govuk-select", local_assigns[:classes]]

--- a/app/views/components/_govuk_textarea.html.slim
+++ b/app/views/components/_govuk_textarea.html.slim
@@ -2,7 +2,7 @@
 / https://github.com/alphagov/govuk-frontend/
 / blob/943ff14752f0a8a765ee3f90bc3e1ecd9205e36c/src/components/textarea/template.njk
 ruby:
-  described_by = ""
+  described_by = local_assigns[:described_by].presence || ""
   has_error = local_assigns[:errorMessage].present?
   rows = local_assigns[:rows] || 5
 

--- a/app/views/components/_govuk_textarea.html.slim
+++ b/app/views/components/_govuk_textarea.html.slim
@@ -2,7 +2,7 @@
 / https://github.com/alphagov/govuk-frontend/
 / blob/943ff14752f0a8a765ee3f90bc3e1ecd9205e36c/src/components/textarea/template.njk
 ruby:
-  described_by = local_assigns[:described_by].presence || ""
+  described_by = local_assigns[:described_by] || ""
   has_error = local_assigns[:errorMessage].present?
   rows = local_assigns[:rows] || 5
 

--- a/govuk_design_system-rails.gemspec
+++ b/govuk_design_system-rails.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name        = "govuk-design-system-rails"
-  s.version     = "0.7.6"
+  s.version     = "0.7.7"
   s.authors     = %w(UKGovernmentBEIS)
   s.summary     = "An implementation of the govuk-frontend macros in Ruby on Rails"
 


### PR DESCRIPTION
This was [previously implemented in the input component](https://github.com/UKGovernmentBEIS/govuk-design-system-rails/pull/34). 
We need to make it available for the rest of the components.

