### PR TITLE
Allow custom CSS on summary list helper rows

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (0.7.8)
+    govuk-design-system-rails (0.8.0)
       slim-rails
 
 GEM

--- a/app/helpers/govuk_design_system/summary_list_helper.rb
+++ b/app/helpers/govuk_design_system/summary_list_helper.rb
@@ -13,8 +13,8 @@ module GovukDesignSystem
       content_tag("dl", attributes) do
         rows.each do |row|
           row = content_tag("div", class: "govuk-summary-list__row") do
-            concat content_tag("dt", (row[:key][:html] || row[:key][:text]), class: "govuk-summary-list__key")
-            concat content_tag("dd", (row[:value][:html] || row[:value][:text]), class: "govuk-summary-list__value")
+            concat content_tag("dt", (row[:key][:html] || row[:key][:text]), class: "govuk-summary-list__key #{row[:key][:classes]}")
+            concat content_tag("dd", (row[:value][:html] || row[:value][:text]), class: "govuk-summary-list__value #{row[:value][:classes]}")
 
             items = row.fetch(:actions, {}).fetch(:items, [])
 

--- a/govuk_design_system-rails.gemspec
+++ b/govuk_design_system-rails.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name        = "govuk-design-system-rails"
-  s.version     = "0.7.8"
+  s.version     = "0.8.0"
   s.authors     = %w(UKGovernmentBEIS)
   s.summary     = "An implementation of the govuk-frontend macros in Ruby on Rails"
 


### PR DESCRIPTION
Custom CSS classes can be provided as part of the row key and value attributes. 
This will allow to tweak the styling for both key and value elements of a summary list row.