### PR TITLE
Update _govuk_hint.html.slim

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (0.8.0)
+    govuk-design-system-rails (0.8.1)
       slim-rails
 
 GEM

--- a/app/views/components/_govuk_hint.html.slim
+++ b/app/views/components/_govuk_hint.html.slim
@@ -1,5 +1,5 @@
 / Implementation based on
 / https://github.com/alphagov/govuk-frontend/
 /       blob/943ff14752f0a8a765ee3f90bc3e1ecd9205e36c/src/components/hint/template.njk
-span *(local_assigns[:attributes] || {}) id=id class=["govuk-hint", local_assigns[:classes]]
+div *(local_assigns[:attributes] || {}) id=id class=["govuk-hint", local_assigns[:classes]]
   = local_assigns[:html] || local_assigns[:text]

--- a/govuk_design_system-rails.gemspec
+++ b/govuk_design_system-rails.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name        = "govuk-design-system-rails"
-  s.version     = "0.8.0"
+  s.version     = "0.8.1"
   s.authors     = %w(UKGovernmentBEIS)
   s.summary     = "An implementation of the govuk-frontend macros in Ruby on Rails"
 


### PR DESCRIPTION
Use a div for the hint, rather than a span. This changed in the govuk component last year but we had not got around to updating it yet, this PR brings our component up to date. https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/components/hint/template.njk